### PR TITLE
remove duplicate link "projects" on nav menu

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,7 +1,8 @@
 <!--Main menu-->
 {{define "nav"}} {{ range .Site.Sections }}
+{{if ne .Title "Projects" }}
 <li><a href="{{ .Permalink }}#content" alt="content {{ .Title }}">{{ .Title }}</a></li>
-{{ end }} {{end}}
+{{ end }} {{ end }} {{end}}
 <div class="menu">
     <div class="container">
         <div class="row">


### PR DESCRIPTION
when the project folder exists in the content directory the menu item projects is duplicated